### PR TITLE
Fix compile warnings to get working with noetic, fixes #19

### DIFF
--- a/include/cyglidar_pcl.h
+++ b/include/cyglidar_pcl.h
@@ -22,7 +22,7 @@
 #define BASE_ANGLE_2D           120
 
 #define DISTANCE_MAX_2D         10000
-#define SIZE_MAX                20000
+#define SCAN_MAX_SIZE           20000
 
 #define INVALID_DATA_2D         16000
 #define LOW_AMPLITUDE_2D        16001
@@ -64,7 +64,7 @@
 #define BYTESET_NUM_3D          3
 
 #define PACKET_HEADER_0         0x5A
-#define PACKET_HEADER_1         0x77        
+#define PACKET_HEADER_1         0x77
 #define PACKET_HEADER_2         0xFF
 
 #define PULSE_LIDAR_TYPE        0
@@ -77,17 +77,6 @@
 #define HEX_SIZE_ONE            4
 #define HEX_SIZE_TWO            8
 #define HEX_SIZE_FOUR           16
-
-static boost::array<uint8_t, 8> PACKET_START_2D = { PACKET_HEADER_0, PACKET_HEADER_1, PACKET_HEADER_2, 0x02, 0x00, 0x01, 0x00, 0x03 };
-static boost::array<uint8_t, 8> PACKET_START_3D = { PACKET_HEADER_0, PACKET_HEADER_1, PACKET_HEADER_2, 0x02, 0x00, 0x08, 0x00, 0x0A };
-static boost::array<uint8_t, 8> PACKET_START_DUAL = { PACKET_HEADER_0, PACKET_HEADER_1, PACKET_HEADER_2, 0x02, 0x00, 0x07, 0x00, 0x05 };
-static boost::array<uint8_t, 8> PACKET_STOP = { PACKET_HEADER_0, PACKET_HEADER_1, PACKET_HEADER_2, 0x02, 0x00, 0x02, 0x00, 0x00 };
-
-static boost::array<uint8_t, 8> PACKET_FREQUENCY = { PACKET_HEADER_0, PACKET_HEADER_1, PACKET_HEADER_2, 0x02, 0x00, 0x0F, 0x00, 0x00 };
-static boost::array<uint8_t, 9> PACKET_INTEGRATION_TIME = { PACKET_HEADER_0, PACKET_HEADER_1, PACKET_HEADER_2, 0x03, 0x00, 0x0C, 0x00, 0x00, 0x00 };
-
-static boost::array<char, HEX_SIZE_TWO> MSB_BUFFER, LSB_BUFFER;
-static boost::array<char, HEX_SIZE_FOUR> BINARY_BUFFER;
 
 namespace CameraIntrinsicParameters
 {
@@ -122,9 +111,9 @@ class cyglidar_pcl
 
       /**
         * @brief Poll the laser to get a new scan. Block until a complete new scan is received or close is called.
-        * @param scan 
+        * @param scan
         */
-      uint8_t* poll(int version); 
+      uint8_t* poll(int version);
 
       /**
         * @brief Send a packet to run CygLiDAR


### PR DESCRIPTION
I found similar issues as discussed in here.
https://github.com/CygLiDAR-ROS/cyglidar_d1/issues/19

This fixes the crash (at least for me) on ROS noetic and Ubuntu 20.04. I resolved ​a number of the compile warnings (not all) and on my system still lets me compile under c++11, but this works for me on c++14/17 as well.

I believe the culprit was that SIZE_MAX was redefined. SIZE_MAX is a constant already defined in `stdint.h` so I chose a different name for it here. Let me know if the name is not accurate to its usage.

Defining static variables in a header is generally discouraged. Every translation unit will have their own copies of those static variables and if they don't use them the compiler will warn about unused variables. Putting them into anonymous namespaces in the `.cpp` file where they are used allows their scope to be limited, while still preventing their export.

There were a couple of functions that didn't return a value though they were given a return type. Generally this isn't an issue, but I've run into problems before where the compiler over optimizes functions in that case